### PR TITLE
fix: surname was swapped with firstName when the name of the guest have more than 1 name

### DIFF
--- a/src/siba.ts
+++ b/src/siba.ts
@@ -110,8 +110,8 @@ export function buildSIBABulletins(
         Email_Contacto: hotelUnit.contactEmail
       },
       Boletim_Alojamento: guests.map(guest => ({
-        Apelido: guest.firstName,
-        Nome: guest.surname || " ",
+        Apelido: guest.surname ? guest.surname : guest.firstName, // if surname exists use surname otherwise use firstName because it only has 1 name
+        Nome: guest.surname ? guest.firstName : " ", // if surname exists use firstName otherwise this field must be set with a space
         Nacionalidade: guest.nationality,
         Data_Nascimento: guest.birthDate && guest.birthDate.toISOString(),
         Local_Nascimento: guest.birthPlace,


### PR DESCRIPTION
As stated in [siba](https://siba.sef.pt/ajuda/modos-de-envio/):

When the guest only has one name:
- the field "Apelido" must be filled with that name
- the field "Name" must be filled with spaces

When the guest has more than one name:
- the field "Name" must be filled with the first name
- the field "Apelido" must be filled with the surname